### PR TITLE
Update Chinese homepage for Skill OS 2.0

### DIFF
--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -2,7 +2,50 @@
 
 `YAO = Yielding AI Outcomes`，中文可理解为：产出 AI 结果，交付真实成果。它强调的不是生成更多 prompt 文本，而是沉淀可复用的 AI 资产与可落地的实际结果。
 
-`yao-meta-skill` 是一套轻量但严谨的系统，用来创建、评估、打包和治理可复用的 agent skill。
+`yao-meta-skill` 用来创建、评估、打包和治理可复用的 agent skill。1.0 的重点是把重复工作流整理成可安装、可阅读、可跨平台的 skill 包；2.0 进一步升级为 Skill OS，把建模、跨端编译、输出评测、评审工作台、证据账本、包体验证、发布门禁和后续迭代串成一套完整流程。
+
+[快速开始](#快速开始) · [Skill OS 2.0 升级](#skill-os-20-升级) · [从 1.0 到 2.0](#从-10-到-20) · [加权质量评测](#加权质量评测) · [与其他元 Skill 的适用差异](#与其他元-skill-的适用差异)
+
+## Skill OS 2.0 升级
+
+Skill OS 2.0 保留 `yao-meta-skill` 原来的轻量入口，但把 skill 的生命周期说得更清楚。它不止生成 `SKILL.md`，还会围绕这个 skill 生成结构化契约、目标平台适配、评测证据、发布门禁和运营报告。
+
+- **Skill IR（技能中间表示）**：用平台无关的结构记录意图、触发方式、输入输出、边界、参考资料和交付产物。
+- **目标编译与适配器**：把同一份 skill 语义编译到 OpenAI、Claude、通用 agent skill、Agent Skills 兼容包和 VS Code 使用场景。
+- **输出评测实验室**：覆盖触发评测、输出断言、执行证据、耗时与 token 证据、基准复现、盲评材料包、答案钥匙和评审裁决报告。
+- **Review Studio 2.0（评审工作台）**：把意图、触发、输出评测、上下文成本、运行时检查、信任扫描、Skill Atlas、采用漂移、豁免、批注、发布证据、警告、阻塞项和修复动作放在同一个 HTML 页面。
+- **证据与发布治理**：提供证据一致性、包体验证、安装模拟、运行时权限探测、世界级证据接收、证据账本、操作运行手册和公开宣传守卫。
+- **SkillOps 闭环**：通过元数据级采用漂移、遥测 hook、自适应建议、日报/周报和组合级漂移信号，把发布后的反馈带回下一轮迭代。
+
+当前发布口径：仓库已经适合进入测试版和外部试用，但更强的“世界级”公开宣传仍然受证据门禁约束。真实生产模型证据、真人盲评证据、原生权限执行和真实客户端遥测会继续作为独立证据任务推进，不会被包装成已经完成。
+
+相关产物：
+
+- [1.0 vs 2.0 可视化对比报告](../.previews/yao-meta-skill-2-comparison/index.html)
+- [中文桌面预览图](../.previews/yao-meta-skill-2-comparison/yao-meta-skill-1-vs-2.png)
+- [英文桌面预览图](../.previews/yao-meta-skill-2-comparison/yao-meta-skill-1-vs-2-en.png)
+
+## 从 1.0 到 2.0
+
+| 维度 | 1.0 重点 | 2.0 升级 |
+| --- | --- | --- |
+| 产品定位 | 创建、重构、评估和打包可复用 skill。 | 治理 skill 的完整生命周期：创建、编译、评测、评审、发布、遥测和迭代。 |
+| 架构模型 | 以 `SKILL.md`、`agents/interface.yaml`、manifest 和报告文件为主。 | 引入 Skill IR、目标编译器、适配器、门禁契约、证据账本、发布锁和行动型评审页面。 |
+| 跨端交付 | 主要覆盖 OpenAI、Claude 和通用包体。 | 扩展到 Agent Skills 兼容包和 VS Code 使用场景，并把兼容结果写入 registry 可读记录。 |
+| 质量模型 | 触发、结构和报告式评审。 | 输出评测、基准复现、执行证据、失败披露、盲评材料包和证据一致性检查。 |
+| 报告体验 | 概览 HTML 和首次评审页面。 | 双语 Skill Overview v2、Review Studio 2.0、评审批注、行动卡片、图表和审计型报告契约。 |
+| 发布边界 | 能生成包体并做基础校验。 | 包体验证、安装模拟、运行时权限探测、发布锁、公开宣传守卫和操作运行手册。 |
+| 运营闭环 | 更多依赖手动反馈和本地迭代。 | 采用漂移、元数据遥测、SkillOps 报告、自适应建议和组合级漂移检测。 |
+
+## 2.0 使用场景
+
+- **从重复工作创建新 skill**：从 workflow 笔记、prompt 集合、转录、runbook 或文档模式出发，生成精简入口、明确输入输出、参考资料、报告和最轻量的必要门禁。
+- **把个人 skill 升级成团队资产**：补齐接口契约、manifest、目标适配器、信任检查、输出评测、评审豁免、发布说明和 Review Studio 证据，再交给多人复用。
+- **准备测试版发布**：运行包体验证、安装模拟、兼容检查、运行时权限探测和证据一致性检查，把测试版就绪和更强公开声明分开处理。
+- **发布后继续迭代**：用元数据级遥测、采用漂移、feedback log、SkillOps 报告和自适应建议判断下一步是补文档、补 eval、改 skill，还是调整治理规则。
+- **与其他元 skill 搭配使用**：保留 Anthropic/OpenAI 式对话创建和精简写作方法的优势，在需要证据、可移植性、发布门禁和长期维护时用 `yao-meta-skill` 加固。
+
+## 能力面
 
 它把粗糙的 workflow、transcript、prompt、notes 和 runbook 转成可复用的 skill 包，并具备：
 
@@ -12,35 +55,53 @@
 - 深度起草前先做一轮更有人味的意图对话，并通过 intent confidence gate 判断理解是否足够清楚；如果不够清楚，会继续补 1 到 2 个高杠杆问题
 - 深度起草前会静默执行 GitHub benchmark scan 和 reference synthesis，优先学习高质量公开项目与世界级模式；只有遇到真实冲突或不确定性时才显式抬给用户
 - 会主动询问用户是否有希望借鉴的参考对象，只学习其中的模式抽象、结构和标准，不复制原文或私密内容
-- 新建 skill 时自动生成一份极简白底 HTML 可视化说明
+- 新建 skill 时自动生成一份默认中文、可切换英文的 HTML 可视化说明报告
+- 提供 Review Studio 2.0，把意图、触发、输出评测、上下文、运行时、信任、采用漂移、豁免、批注、发布证据和修复动作汇总到一个页面
+- 提供 Skill OS 2.0 审计，把世界级要求拆成本地证据、人类证据缺口和外部证据缺口
+- 提供证据计划、证据账本、证据接收契约、提交审查队列、操作运行手册和公开宣传守卫，避免把计划中的工作写成已经完成
+- 提供基准复现 manifest、证据一致性检查、输出评测实验室、盲评包和评审裁决报告
+- 提供运行时权限探测、Python 兼容性门禁、包体验证和安装模拟
 - 提供 prompt quality profile，把需求模型、RTF 映射、复杂度和提示词质量检查沉淀成 reviewer 可见证据，而不是塞进 `SKILL.md`
+- 提供 artifact design profile，约束报告、教程、仪表盘、截图和评审页的视觉与质量标准
+- 提供系统思考模型，记录边界、反馈环、漂移风险、复发失败模式和高杠杆改进点
 - 首次建包后会自动给出 3 个最有价值的下一步迭代方向
 - 提供一个紧凑的 HTML review viewer，方便第一次人工理解和评审
 - 提供一个轻量 feedback log，不必每次都走完整 promotion 流程
+- 提供本地优先、只记录元数据的 adoption drift 报告、CLI 运行捕获、外部客户端事件 hook、hook recipe 和 JSONL 导入
+- 提供显式来源的 adaptive proposal loop，从脱敏重复偏好里生成需要人工批准的改进建议
+- 提供 SkillOps 机会评分、决策策略、日报、周报和组合级漂移信号
 - 提供一个 with-skill vs baseline 的对比报告，便于快速看增量收益
 - 提供一个更像对话发现流程的 archetype-aware quickstart，引导新 skill 落到 scaffold、production、library 或 governed 的合适形态
-- 中性的源元数据以及面向不同客户端的适配层
+- Skill IR 作为平台无关语义契约，并提供编译报告和客户端适配层
+- registry audit 元数据，包含 package version、owner、license、checksum 和 compatibility matrix
 - 内建的治理、晋升和 portability 检查
 
 ## 架构图
 
-Hero 版可以压缩成一条主线：把零散输入变成一个可治理、可复用的 skill 包。
+Hero 版可以压缩成一条主线：Skill OS 2.0 把零散输入变成一个可治理、可评测、可发布、可持续迭代的 skill 包。
 
 ```mermaid
 flowchart LR
-    A["输入<br/>workflow / prompt / transcript / docs / notes"] --> B["路由<br/>SKILL.md"]
-    B --> C["设计<br/>方法 + 质量门"]
-    C --> D["执行<br/>create / validate / eval / promote"]
-    D --> E["产出<br/>skill 包 + 报告 + 适配层"]
+    A["输入<br/>workflow / prompt / transcript / docs / notes"] --> B["意图建模<br/>任务 / 输出 / 排除项 / 标准"]
+    B --> C["Skill IR<br/>触发 / 契约 / 资源 / 证据"]
+    C --> D["Skill 包<br/>SKILL.md / references / scripts / reports"]
+    C --> E["目标编译<br/>OpenAI / Claude / generic / Agent Skills / VS Code"]
+    D --> F["评测实验<br/>触发 / 输出 / 基准 / 运行时"]
+    E --> F
+    F --> G["Review Studio<br/>门禁 / 警告 / 动作 / 豁免"]
+    G --> H["发布边界<br/>包体验证 / 安装模拟 / 宣传守卫"]
+    H --> I["SkillOps 闭环<br/>反馈 / 采用漂移 / 下一轮迭代"]
+    I --> B
 ```
 
 10 秒理解这张图：
 
-- **输入**：从零散的 workflow、prompt、文档和笔记出发。
-- **路由**：先用精简的 `SKILL.md` 定义边界和触发。
-- **设计**：选择合适的 archetype、gates 和资源拆分方式。
-- **执行**：通过统一 CLI 完成创建、校验、优化和晋升。
-- **产出**：最终得到 skill 包，以及评测、治理和 portability 证据。
+- **输入**：从零散 workflow、prompt、文档和笔记出发，不要求一开始就有完整规格。
+- **意图建模**：先把任务、输出物、排除项、约束和质量标准说清楚，再生成文件。
+- **Skill IR**：把语义契约和具体平台格式拆开，避免被某一个客户端锁死。
+- **打包与编译**：从同一份源模型生成精简 skill 包和目标平台适配产物。
+- **评测与评审**：把触发行为、输出质量、运行时检查和信任信号变成可复查证据。
+- **发布与运营**：只在当前证据边界内发布，再把采用漂移和评审反馈带回下一轮迭代。
 
 ## 加权质量评测
 
@@ -60,7 +121,7 @@ flowchart LR
 | 2 | Anthropic Skill Creator | 67.5 | 方法论和迭代闭环强，但本地执行可靠性和治理覆盖较弱。 |
 | 3 | OpenAI Skill Creator | 50.5 | 更适合作为精简 skill 写作方法论教材，而不是完整工程系统。 |
 
-## 适用场景
+## 与其他元 Skill 的适用差异
 
 - 如果你要的是**团队复用、显式边界、质量门、治理、可移植性和长期维护**，更适合 `Yao Meta Skill`。
 - 如果你要的是**对话优先的创作循环和人工引导式迭代**，更适合 `Anthropic Skill Creator`。
@@ -73,30 +134,31 @@ flowchart LR
 2. 先做一轮简短但更有人味的意图对话，把真实任务、输出物、边界、约束和你在意的质量标准说清楚。
 3. 先让 `quickstart` 澄清意图，再静默跑 benchmark scan 和 reference synthesis；只有当意图还不清楚，或者设计路线真的冲突时，才会显式继续追问或让你拍板。
 4. 使用 archetype-aware 的 `quickstart` 或完整作者流，在 scaffold、production、library 或 governed 模式下生成或改进 skill 包。
-5. 新建 skill 后，会默认附带 `reports/intent-dialogue.md`、`reports/intent-confidence.md`、`reports/reference-synthesis.md`、`reports/artifact-design-profile.md`、`reports/prompt-quality-profile.md`、`reports/skill-overview.html`、`reports/review-viewer.html` 和 `reports/iteration-directions.md`；后续还可以通过 feedback log 和 baseline compare 快速收集意见、查看增量收益，而不必每次都走完整 promotion 流程。
+5. 新建 skill 后，先看 `reports/skill-interpretation.html` 理解双语解释报告，再打开 `reports/skill-overview.html` 查看概述、指标、原理、边界、质量、风险、资产和路线，最后用 `reports/review-studio.html` 检查发布阻塞、权限批准和证据路径。
 
 ## 当前结果
 
-- 当前 `make test` 可通过
+- 当前 `make test` 和 GitHub Actions `test` 可通过
 - 当前回归集下 trigger eval 为 `0` 误触发、`0` 漏触发
 - train / dev / holdout 三层评测均通过
 - 中文真实表达已经纳入触发评测，覆盖“做一个 skill”“沉淀成可复用能力”“优化已有 skill”“补 trigger 评测”等常见说法
-- `openai`、`claude`、`generic` 三个目标的 packaging contract 校验通过
+- registry 记录的目标平台从 OpenAI、Claude、Generic 扩展到 Agent Skills 和 VS Code 相关适配
+- Review Studio 当前汇总 16 个门禁，包体验证、安装模拟、证据一致性和发布声明边界已经进入报告链路
 
 ## 当前优势
 
-最新加权评测中，Yao 的总分是 `91.5/100`。最强的部分集中在团队级 skill 资产真正需要的能力上：
+最新加权评测中，Yao 的总分是 `91.5/100`。2.0 的强项集中在团队级 skill 资产真正需要的能力上：
 
 - **方法论深度 `9.5`**：已经形成正式的 skill engineering doctrine，覆盖 archetype、gate selection、non-skill decision、governance 和 resource boundary。
-- **工具链完整度 `9.5`**：初始化、校验、benchmark scan、description optimization、报告、晋升检查、打包、CI 和 portability checks 已经串成一条完整工具链。
-- **Eval / 测试严谨度 `9.5`**：触发评测覆盖 train/dev/holdout、blind holdout、adversarial holdout、judge-backed blind eval、route confusion、drift history 和 promotion gate。
-- **治理 / 生命周期 `9.5`**：重要 skill 可以声明 owner、生命周期、review cadence、maturity score、trust boundary、promotion decision 和 regression history。
+- **工具链完整度 `9.5`**：初始化、校验、benchmark scan、description optimization、Skill IR、目标编译、报告、晋升检查、打包、CI 和 portability checks 已经串成一条完整工具链。
+- **Eval / 测试严谨度 `9.5`**：触发评测覆盖 train/dev/holdout、blind holdout、adversarial holdout、judge-backed blind eval、route confusion、drift history、output eval 和 promotion gate。
+- **治理 / 生命周期 `9.5`**：重要 skill 可以声明 owner、生命周期、review cadence、maturity score、trust boundary、promotion decision、regression history、release lock 和 evidence ledger。
 - **本地可执行可靠性 `9.5`**：可以通过 `make test`、`make ci-test` 和统一 CLI 在本地复验。
 - **可移植 / 分发能力 `9.0`**：源码保持中性，adapter、degradation rule、packaging contract 和 portability score 负责保留跨环境可复用语义。
 - **上下文纪律 / 精简度 `8.0`**：入口仍保持在预算内，但因为系统承载了更多报告、案例、benchmark 和证据资产，这一项被持续作为约束跟踪。
 - **上手 / 评审体验 `6.5`**：quickstart、HTML overview、side-by-side review viewer 和 feedback log 已经改善首次体验，但仍是下一阶段最值得优化的 UX 维度。
 
-整体方向很明确：入口尽量轻，评测尽量硬，治理显性化，同时继续降低首次创建和人工评审的摩擦。
+整体方向很明确：入口尽量轻，评测尽量硬，治理显性化；测试版可以开放试用，但公开宣传会继续受证据账本约束。
 
 ## 为什么是 Yao
 
@@ -107,7 +169,7 @@ flowchart LR
 
 ## 它能做什么
 
-这个项目帮助你把 skill 从一次性 prompt，升级成可创建、可重构、可评估、可打包的长期能力包。
+这个项目帮助你把 skill 从一次性 prompt，升级成可创建、可重构、可评估、可打包、可审计、可发布、可持续迭代的长期能力包。
 
 它的设计逻辑很简单：
 


### PR DESCRIPTION
## Summary

- Sync the Chinese homepage with the English Skill OS 2.0 positioning.
- Add Chinese sections for the 2.0 upgrade, 1.0 to 2.0 comparison, use cases, and updated architecture flow.
- Preserve the existing weighted benchmark and comparison with Anthropic/OpenAI meta-skill approaches.

## Verification

- Checked required Chinese README sections.
- Checked relative links to the comparison report preview artifacts.
- Ran git diff --check.