### PR TITLE
fix: run on Windows by making the fcntl import optional

### DIFF
--- a/scripts/evidence_store.py
+++ b/scripts/evidence_store.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import contextlib
-import fcntl
 import hashlib
 import json
 import os
@@ -17,6 +16,32 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterator
+
+try:
+    import fcntl
+except ModuleNotFoundError:  # Windows has no fcntl; fall back to msvcrt region locks.
+    fcntl = None
+    import msvcrt
+
+
+def _lock_exclusive_nonblocking(descriptor: int) -> None:
+    """Raises BlockingIOError when the lock is held elsewhere, on both platforms."""
+    if fcntl is not None:
+        fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    try:
+        msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+    except OSError as exc:
+        raise BlockingIOError(exc.errno, str(exc)) from exc
+
+
+def _unlock(descriptor: int) -> None:
+    if fcntl is not None:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        return
+    os.lseek(descriptor, 0, os.SEEK_SET)
+    msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
 
 
 SCRIPT_INTERFACE = "internal-module"
@@ -364,7 +389,7 @@ class EvidenceStore:
         descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
         try:
             try:
-                fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                _lock_exclusive_nonblocking(descriptor)
             except BlockingIOError as exc:
                 raise EvidenceError("publish-locked", f"Another evidence publish holds {lock_path}") from exc
             os.ftruncate(descriptor, 0)
@@ -372,7 +397,7 @@ class EvidenceStore:
             yield
         finally:
             with contextlib.suppress(OSError):
-                fcntl.flock(descriptor, fcntl.LOCK_UN)
+                _unlock(descriptor)
             os.close(descriptor)
 
     def _restore_bundle(self, bundle_dir: Path, *, expected_index_sha256: str | None = None) -> None:

--- a/tests/verify_evidence_build.py
+++ b/tests/verify_evidence_build.py
@@ -21,6 +21,15 @@ from evidence_resolver import resolve_evidence_path  # noqa: E402
 from evidence_store import EvidenceError, EvidenceStore  # noqa: E402
 
 
+def try_symlink(link: Path, target: Path, *, target_is_directory: bool = False) -> bool:
+    """False when the platform refuses symlinks (Windows without Developer Mode or admin)."""
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except OSError:
+        return False
+    return True
+
+
 def write_skill(root: Path, name: str, marker: str) -> None:
     (root / "reports").mkdir(parents=True)
     (root / "agents").mkdir()
@@ -101,14 +110,16 @@ def main() -> None:
 
         outside = temp_root / "outside.json"
         outside.write_text("{}", encoding="utf-8")
-        (alpha / "reports" / "escape.json").symlink_to(outside)
-        try:
-            alpha_store.build("symlink-run")
-        except EvidenceError as exc:
-            assert exc.code == "unsafe-artifact", exc
+        if try_symlink(alpha / "reports" / "escape.json", outside):
+            try:
+                alpha_store.build("symlink-run")
+            except EvidenceError as exc:
+                assert exc.code == "unsafe-artifact", exc
+            else:
+                raise AssertionError("symlink artifact was accepted")
+            (alpha / "reports" / "escape.json").unlink()
         else:
-            raise AssertionError("symlink artifact was accepted")
-        (alpha / "reports" / "escape.json").unlink()
+            print("skipped symlink artifact case: platform does not permit symlinks")
 
         (alpha_run.run_dir / "raw-outputs").mkdir()
         (alpha_run.run_dir / "raw-outputs" / "private.txt").write_text("raw provider output", encoding="utf-8")
@@ -395,14 +406,16 @@ def main() -> None:
         published_reports = beta / ".yao" / "releases" / "cli-publish" / "artifacts" / "reports"
         external_published_reports = temp_root / "external-published-reports"
         shutil.move(str(published_reports), external_published_reports)
-        published_reports.symlink_to(external_published_reports, target_is_directory=True)
-        try:
-            resolve_evidence_path(beta, "reports/quality.json")
-        except EvidenceError as exc:
-            assert exc.code == "unsafe-evidence-path", exc
+        if try_symlink(published_reports, external_published_reports, target_is_directory=True):
+            try:
+                resolve_evidence_path(beta, "reports/quality.json")
+            except EvidenceError as exc:
+                assert exc.code == "unsafe-evidence-path", exc
+            else:
+                raise AssertionError("evidence resolver followed a symlink outside the immutable release")
+            published_reports.unlink()
         else:
-            raise AssertionError("evidence resolver followed a symlink outside the immutable release")
-        published_reports.unlink()
+            print("skipped symlink evidence-path case: platform does not permit symlinks")
         shutil.move(str(external_published_reports), published_reports)
         (beta / "SKILL.md").write_text((beta / "SKILL.md").read_text(encoding="utf-8") + "\nDirty.\n", encoding="utf-8")
         rejected = subprocess.run(


### PR DESCRIPTION
## Problem

`scripts/evidence_store.py` imports `fcntl` at module scope. `fcntl` is Unix-only, so on Windows the import itself fails:

```
ModuleNotFoundError: No module named 'fcntl'
```

`yao.py` imports `evidence_store` transitively, so this happens before argument parsing — **every** subcommand is unreachable on Windows, including `check-update`, `self-update`, and `validate`. `scripts/trigger_eval.py` is affected the same way.

## Change

- `scripts/evidence_store.py`: `fcntl` becomes an optional import. Where it is missing, `publish_lock` takes the exclusive lock via `msvcrt.locking(..., LK_NBLCK, 1)`. Both helpers raise `BlockingIOError` on contention, so `publish_lock`'s existing `publish-locked` error path is unchanged.
- `tests/verify_evidence_build.py`: the two `symlink_to` calls are guarded. Windows refuses symlink creation without Developer Mode or admin rights, which aborted the test before it reached any assertion. The symlink security assertions still run wherever symlinks are permitted, and print a skip line where they are not.

**POSIX behavior is unchanged by construction** — when `fcntl` imports successfully, the executed code is the same `flock` call as before.

## Verification

Windows 11, Python 3.13:

- `python tests/verify_evidence_build.py` → `{"ok": true}` (previously `OSError: [WinError 1314]`)
- `python scripts/yao.py check-update` → returns its report (previously `ModuleNotFoundError`)
- `python scripts/yao.py validate <skill>` → runs the full gate pipeline and reports real findings
- Lock semantics checked directly: second non-blocking acquire on a held lock raises `BlockingIOError`, and succeeds after release
- All 174 files in `scripts/` byte-compile

## Two further Windows issues, not addressed here

Kept out of this PR to keep it reviewable — happy to open issues or follow-up PRs if useful:

1. **Non-UTF-8 console locales.** ~98 scripts `print(json.dumps(..., ensure_ascii=False))`. On a Japanese Windows console (cp932) any CJK output raises `UnicodeEncodeError` (e.g. `render_world_class_claim_guard.py`). `PYTHONUTF8=1` works around it; a durable fix needs a shared stdout setup, which touches far more files than this change.
2. **Backslash path separators in generated reports.** Report JSON records e.g. `evidence\world_class\submissions`, so `evidence-consistency` flags drift against the POSIX-style expectation.
