### PR TITLE
fix(review-studio): serialize report JSON with default=str

### DIFF
--- a/scripts/render_review_studio.py
+++ b/scripts/render_review_studio.py
@@ -573,7 +573,7 @@ def render_review_studio(skill_dir: Path, output_html: Path | None = None, outpu
         },
     }
     output_html.write_text(render_html(report), encoding="utf-8")
-    output_json.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    output_json.write_text(json.dumps(report, ensure_ascii=False, indent=2, default=str) + "\n", encoding="utf-8")
     return {key: value for key, value in report.items() if key != "data"}
 
 


### PR DESCRIPTION
## Problem

`render_review_studio.py` crashes with `TypeError: Object of type date is not JSON serializable` when trust_check's ISO date parsing (`parse_iso_date`) puts `datetime.date` objects into the report data. Any external skill package whose governance data yields a date object cannot get a review-studio report at all — the JSON artifact write fails and the CLI returns rc=1.

Reproduced while running the standard external flow (`compile-skill` → `output-eval` → `review-studio`) on a third-party skill package (an evidence-portrait skill exported via a Skill IR 2.0 contract); yao's own self-audit doesn't hit it because its own data happens to contain no raw date objects.

## Fix

One line: `json.dumps(..., default=str)` on the report JSON dump in `render_review_studio.py`. Non-serializable values (dates and any future non-primitive) are coerced to strings; the HTML rendering path is unchanged.

## Verification

- Before: `review-studio <external-skill>` → rc=1, `TypeError: Object of type date is not JSON serializable`, no report produced.
- After: `review-studio` returns ok:true, 16 gates rendered, JSON + HTML artifacts written (`summary.decision: review`, 0 blockers on the test package).
- `yao.py validate . --self` still passes; yao's own reports unchanged.